### PR TITLE
Add markdown scraper with offline fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,59 @@
-# CF-Contest-Problem-Scrapper
+# Codeforces Contest Markdown Scraper
 
-CF-Contest-Problem-Scrapper is a JavaScript-based tool designed to scrape contest problems from Codeforces During the Contest. This tool helps users to collect and organize problems from various contests for easy access and analysis.
+This project downloads Codeforces contest problems together with their linked tutorials and stores every pair as a Markdown document. Each generated file contains:
 
-## Features
+- Contest metadata (name, limits and IO format)
+- A cleaned version of the problem statement
+- Input and output specifications
+- All sample tests with fenced code blocks
+- The official tutorial (when a link is published on the problem page)
 
-- Scrape contest problems from Codeforces.
-- Organize and save problem data in a structured format.
+The tool works with the public Codeforces website, but it can also operate in an offline mode that consumes pre-downloaded HTML snapshots. The repository contains an example snapshot and its generated Markdown output so you can see a successful run without external network access.
+
+## Installation
+
+The CLI runs with Node.js (>= 18). Install the dependencies once:
+
+```bash
+npm install
+```
 
 ## Usage
 
-To use the CF-Contest-Problem-Scrapper, run the following command:
+Download every problem from a contest and write Markdown files into the `output` directory:
 
-##### cmd :
-```sh
-npx cf-contest
+```bash
+node script.js 1971
 ```
 
-##### Example : 
-```
-npx cf-contest
-Enter Contest ID : 2026        //contest-id available in contest URL
-Your Name :- manish-dev        //name
-```
+Key options:
 
-# Folder Structure for Contest
+- `-o, --output <dir>` – change the target directory (default: `output`).
+- `-b, --base-url <url>` – use a different Codeforces mirror.
+- `--offline-dir <dir>` – read HTML from a local folder instead of making HTTP requests.
+- `-v, --verbose` – print progress information for every problem.
 
-Below is the folder structure for organizing contest problems and their respective files.
+The command exits with a non-zero status code if the contest cannot be downloaded or a problem is missing its statement.
 
-```
-contest-name/
-│
-├── A/
-│   ├── input.in
-│   ├── output.out
-│   ├── expected.out
-│   ├── problemstatement.txt
-│   └── solution.cpp
-│
-├── B/
-│   ├── input.in
-│   ├── output.out
-│   ├── expected.out
-│   ├── problemstatement.txt
-│   └── solution.cpp
-│
-├── C/
-│   ├── input.in
-│   ├── output.out
-│   ├── expected.out
-│   ├── problemstatement.txt
-│   └── solution.cpp
-│
-└── ...
+## Offline fixtures and example output
+
+The repository ships with a minimal offline fixture under `fixtures/beta_round_1`. It contains HTML snapshots of **Codeforces Beta Round #1** problem A and its official tutorial. Running the scraper on that fixture produces the Markdown file stored at `output/1-Codeforces Beta Round #1/A-theatre-square.md`.
+
+To reproduce the example:
+
+```bash
+node script.js 1 --offline-dir fixtures/beta_round_1 --output output --verbose
 ```
 
-## Explanation
-1. **`contest-name/`**  
-   The root folder representing the name of the contest.  
+The command above was executed to generate the committed sample Markdown file.
 
-2. **`A/`, `B/`, `C/`**  
-   Subdirectories named after individual contest problems.  
+## Project structure
 
-3. **Files in Each Problem Directory**  
-   - **`input.in`**: The input file for the problem.  
-   - **`output.out`**: The generated output after running the solution.  
-   - **`expected.out`**: The expected correct output for comparison.  
-   - **`problemstatement.txt`**: The text file containing the problem statement.  
-   - **`solution.cpp`**: The solution code written in C++.  
+```
+output/
+└── <contest id>-<contest name>/
+    └── <problem index>-<problem-name>.md
+```
 
-Add additional problem folders as needed using the same structure (`D/`, `E/`, etc.).  
+Each Markdown document includes the tutorial text at the end. If a problem does not provide a tutorial link, the scraper adds a placeholder message so the absence is explicit.
+

--- a/fixtures/beta_round_1/contest.html
+++ b/fixtures/beta_round_1/contest.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Codeforces Beta Round #1</title></head>
+<body>
+  <div class="rtable">
+    <div class="left">Codeforces Beta Round #1</div>
+  </div>
+  <table class="problems">
+    <tr>
+      <td class="id"><a href="/contest/1/problem/A">A</a></td>
+      <td class="name"><a href="/contest/1/problem/A">Theatre Square</a></td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/fixtures/beta_round_1/problem_A.html
+++ b/fixtures/beta_round_1/problem_A.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>A. Theatre Square</title></head>
+<body>
+  <div class="problem-statement">
+    <div class="header">
+      <div class="title">A. Theatre Square</div>
+    </div>
+    <div class="time-limit">Time limit per test 1 second</div>
+    <div class="memory-limit">Memory limit per test 256 megabytes</div>
+    <div class="input-file">Input standard input</div>
+    <div class="output-file">Output standard output</div>
+    <p>Theatre Square in the capital city of Berland has a rectangular shape of n &times; m meters. Some corporation has
+      bought an arena in this square and is planning to pave the Square with square granite flagstones. Each flagstone is
+      a square of a &times; a meters.</p>
+    <p>What is the least number of flagstones needed to pave the Square? It is allowed to cover the surface larger than the
+      Theater Square, but the Square has to be fully covered. It is not allowed to break the flagstones. The sides of
+      flagstones should be parallel to the sides of the Square.</p>
+    <div class="input-specification">
+      <div class="section-title">Input</div>
+      <p>The only line of the input contains three positive integer numbers n, m and a (1 &le; n, m, a &le; 10<sup>9</sup>).</p>
+    </div>
+    <div class="output-specification">
+      <div class="section-title">Output</div>
+      <p>Write the needed number of flagstones.</p>
+    </div>
+    <div class="sample-tests">
+      <div class="sample-test">
+        <div class="input"><div class="title">input</div><pre>6 6 4</pre></div>
+        <div class="output"><div class="title">output</div><pre>4</pre></div>
+      </div>
+    </div>
+    <div class="note">
+      <div class="section-title">Note</div>
+      <p>In the sample, the Theatre Square can be covered by four flagstones sized 4 &times; 4.</p>
+    </div>
+    <div class="footer">
+      <a href="/blog/entry/434">Tutorial</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/fixtures/beta_round_1/tutorial_A.html
+++ b/fixtures/beta_round_1/tutorial_A.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Theatre Square Tutorial</title></head>
+<body>
+  <div class="ttypography">
+    <p>The task asks for the minimum number of square tiles of side <em>a</em> required to cover an <em>n</em> by <em>m</em>
+      rectangle.</p>
+    <p>The answer is the product of the horizontal and vertical counts. Each count equals the ceiling of the dimension
+      divided by <em>a</em>: <code>ceil(n / a) * ceil(m / a)</code>.</p>
+    <p>Use integer arithmetic: <code>((n + a - 1) / a) * ((m + a - 1) / a)</code> with 64-bit integers.</p>
+  </div>
+</body>
+</html>

--- a/output/1-Codeforces Beta Round #1/A-theatre-square.md
+++ b/output/1-Codeforces Beta Round #1/A-theatre-square.md
@@ -1,0 +1,49 @@
+# A. Theatre Square
+
+- Contest: Codeforces Beta Round #1 (1)
+- Time limit per test 1 second
+- Memory limit per test 256 megabytes
+- Input standard input
+- Output standard output
+
+## Problem Statement
+
+Theatre Square in the capital city of Berland has a rectangular shape of n × m meters. Some corporation has bought an arena in this square and is planning to pave the Square with square granite flagstones. Each flagstone is a square of a × a meters.
+
+What is the least number of flagstones needed to pave the Square? It is allowed to cover the surface larger than the Theater Square, but the Square has to be fully covered. It is not allowed to break the flagstones. The sides of flagstones should be parallel to the sides of the Square.
+
+## Input
+
+The only line of the input contains three positive integer numbers n, m and a (1 ≤ n, m, a ≤ 10^9).
+
+## Output
+
+Write the needed number of flagstones.
+
+## Sample Tests
+
+### Sample 1
+
+**Input**
+
+```text
+6 6 4
+```
+
+**Output**
+
+```text
+4
+```
+
+## Note
+
+In the sample, the Theatre Square can be covered by four flagstones sized 4 × 4.
+
+## Tutorial
+
+The task asks for the minimum number of square tiles of side *a* required to cover an *n* by *m* rectangle.
+
+The answer is the product of the horizontal and vertical counts. Each count equals the ceiling of the dimension divided by *a*: `ceil(n / a) * ceil(m / a)`.
+
+Use integer arithmetic: `((n + a - 1) / a) * ((m + a - 1) / a)` with 64-bit integers.

--- a/src/htmlToMarkdown.js
+++ b/src/htmlToMarkdown.js
@@ -1,0 +1,146 @@
+const cheerio = require('cheerio');
+
+function normalizeWhitespace(text) {
+    return text.replace(/\s+/g, ' ').trim();
+}
+
+function wrapInline(text) {
+    return text.replace(/\s+/g, ' ');
+}
+
+function renderInline($, node) {
+    if (node.type === 'text') {
+        return wrapInline(node.data || '');
+    }
+
+    if (node.type === 'comment') {
+        return '';
+    }
+
+    const children = [];
+    node.children && node.children.forEach(child => {
+        children.push(renderInline($, child));
+    });
+    const content = children.join('');
+
+    switch (node.name) {
+        case 'em':
+        case 'i':
+            return content ? `*${content}*` : '';
+        case 'strong':
+        case 'b':
+            return content ? `**${content}**` : '';
+        case 'code':
+            return content ? `\`${content}\`` : '';
+        case 'a': {
+            const href = $(node).attr('href');
+            return href ? `[${content || href}](${href})` : content;
+        }
+        case 'span':
+            if ($(node).hasClass('tex-math') || $(node).hasClass('tex-span')) {
+                const mathText = normalizeWhitespace($(node).text());
+                return mathText ? `$${mathText}$` : '';
+            }
+            return content;
+        case 'sup':
+            return content ? `^${content}` : '';
+        case 'sub':
+            return content ? `_${content}` : '';
+        default:
+            return content;
+    }
+}
+
+function renderBlock($, node, depth = 0) {
+    if (node.type === 'text') {
+        return normalizeWhitespace(node.data || '') + '\n\n';
+    }
+
+    if (node.type === 'comment') {
+        return '';
+    }
+
+    const $node = $(node);
+    const children = [];
+    node.children && node.children.forEach(child => {
+        children.push(renderBlock($, child, depth + 1));
+    });
+    const childContent = children.join('');
+
+    switch (node.name) {
+        case 'p':
+            return `${renderInline($, node)}\n\n`;
+        case 'br':
+            return '  \n';
+        case 'ul': {
+            return node.children
+                .filter(child => child.type !== 'text' || normalizeWhitespace(child.data))
+                .map(child => renderListItem($, child, depth, '-'))
+                .join('') + '\n';
+        }
+        case 'ol': {
+            let index = 1;
+            return node.children
+                .filter(child => child.type !== 'text' || normalizeWhitespace(child.data))
+                .map(child => renderListItem($, child, depth, `${index++}.`))
+                .join('') + '\n';
+        }
+        case 'li': {
+            const marker = depth ? '  '.repeat(depth - 1) + '-' : '-';
+            const body = node.children ? node.children.map(child => renderBlock($, child, depth + 1)).join('').trim() : '';
+            return `${marker} ${body}\n`;
+        }
+        case 'pre': {
+            const code = $node.text().replace(/\s+$/, '');
+            return `\n\n\`\`\`text\n${code}\n\`\`\`\n\n`;
+        }
+        case 'code':
+            return `\`${renderInline($, node)}\``;
+        case 'div': {
+            if ($node.hasClass('section-title')) {
+                const title = normalizeWhitespace($node.text());
+                return title ? `### ${title}\n\n` : '';
+            }
+            return childContent;
+        }
+        case 'span':
+            return renderInline($, node);
+        case 'table':
+        case 'tbody':
+        case 'tr':
+        case 'td':
+        case 'th':
+            return normalizeWhitespace($node.text()) + '\n\n';
+        default:
+            return childContent;
+    }
+}
+
+function renderListItem($, node, depth, marker) {
+    if (node.type === 'text') {
+        const text = normalizeWhitespace(node.data || '');
+        return text ? `${marker} ${text}\n` : '';
+    }
+    const $node = $(node);
+    if (node.name !== 'li') {
+        return renderBlock($, node, depth + 1);
+    }
+    const body = node.children ? node.children.map(child => renderBlock($, child, depth + 2)).join('').trim() : '';
+    const prefix = depth ? '  '.repeat(depth) + marker : marker;
+    return `${prefix} ${body}\n`;
+}
+
+function htmlFragmentToMarkdown(htmlFragment) {
+    const $ = cheerio.load(`<root>${htmlFragment}</root>`);
+    const root = $('root')[0];
+    if (!root || !root.children) {
+        return '';
+    }
+    const parts = root.children.map(child => renderBlock($, child)).join('');
+    return parts.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+module.exports = {
+    htmlFragmentToMarkdown,
+};
+

--- a/src/problemDetails.js
+++ b/src/problemDetails.js
@@ -1,44 +1,86 @@
 const cheerio = require('cheerio');
-const fs = require('fs/promises');
+const { htmlFragmentToMarkdown } = require('./htmlToMarkdown');
 
-async function getProblemDetails(contestId, problem) {
-    let result = await fetch("https://codeforces.com/contest/"+contestId+"/problem/" + problem)
-        .then((res) => {
-            if (!res.ok) throw new Error(`HTTP error! Status: ${res.status}`);
-            return res.text();
+async function getProblemDetails(fetchPage, contestId, problemIndex) {
+    const problemPath = `/contest/${contestId}/problem/${problemIndex}`;
+    const html = await fetchPage(problemPath, { kind: 'problem', index: problemIndex });
+    const $ = cheerio.load(html);
+    const statement = $('.problem-statement');
+
+    if (!statement.length) {
+        throw new Error(`Unable to find problem statement for ${problemIndex}`);
+    }
+
+    const titleText = statement.find('.header .title').text().trim();
+    const titleMatch = titleText.match(/^([A-Z][0-9A-Z]*)\.\s*(.*)$/);
+    const problemName = titleMatch ? titleMatch[2] : titleText;
+
+    const timeLimit = statement.find('.time-limit').text().replace(/\s+/g, ' ').trim();
+    const memoryLimit = statement.find('.memory-limit').text().replace(/\s+/g, ' ').trim();
+    const inputFile = statement.find('.input-file').text().replace(/\s+/g, ' ').trim();
+    const outputFile = statement.find('.output-file').text().replace(/\s+/g, ' ').trim();
+
+    const problemDescription = [];
+    statement.children().each((_, element) => {
+        const $el = $(element);
+        if ($el.hasClass('header') || $el.hasClass('time-limit') || $el.hasClass('memory-limit') || $el.hasClass('input-file') || $el.hasClass('output-file') || $el.hasClass('input-specification') || $el.hasClass('output-specification') || $el.hasClass('sample-tests') || $el.hasClass('note') || $el.hasClass('footer')) {
+            return;
+        }
+        problemDescription.push($.html(element));
+    });
+
+    const inputSectionElem = statement.find('.input-specification').clone();
+    inputSectionElem.find('.section-title').remove();
+    const inputSection = inputSectionElem.html() || '';
+
+    const outputSectionElem = statement.find('.output-specification').clone();
+    outputSectionElem.find('.section-title').remove();
+    const outputSection = outputSectionElem.html() || '';
+
+    const noteSectionElem = statement.find('.note').clone();
+    noteSectionElem.find('.section-title').remove();
+    const noteSection = noteSectionElem.html() || '';
+
+    const samples = [];
+    statement.find('.sample-tests .sample-test').each((index, sampleEl) => {
+        const sample = $(sampleEl);
+        const input = sample.find('.input pre').text().replace(/\s+$/, '');
+        const output = sample.find('.output pre').text().replace(/\s+$/, '');
+        const explanation = sample.find('.sample-comment').html();
+        samples.push({
+            index: index + 1,
+            input,
+            output,
+            explanation: explanation ? htmlFragmentToMarkdown(explanation) : '',
         });
+    });
 
-    const $ = cheerio.load(result);
-
-    const problemStatement = $('.problem-statement > div > p').not('.input-specification p, .output-specification p, .sample-tests p, .note p').text().trim();
-    const inputSpecification = $('.input-specification p')
-        .map((i, el) => $(el).text().trim())
-        .get()
-        .join(' ');
-
-    const outputSpecification = $('.output-specification p')
-        .map((i, el) => $(el).text().trim())
-        .get()
-        .join(' ');
-
-    const inputExample = $('.sample-tests .input pre div')
-        .map((_, el) => $(el).text().trim())
-        .get()
-        .join('\n');
-
-    const outputExample = $('.sample-tests .output pre')
-        .text()
-        .split('\n')
-        .map(line => line.trim())
-        .filter(line => line);
+    const tutorialLink = statement.find('a').filter((_, el) => $(el).text().toLowerCase().includes('tutorial')).first().attr('href');
+    let tutorialMarkdown = '';
+    if (tutorialLink) {
+        const tutorialPath = tutorialLink.startsWith('http') ? tutorialLink : tutorialLink.startsWith('/') ? tutorialLink : `/contest/${contestId}/${tutorialLink}`;
+        const tutorialHtml = await fetchPage(tutorialPath, { kind: 'tutorial', index: problemIndex });
+        const tutorial$ = cheerio.load(tutorialHtml);
+        const typography = tutorial$('.ttypography');
+        tutorialMarkdown = typography.length ? htmlFragmentToMarkdown(tutorial$.html(typography)) : htmlFragmentToMarkdown(tutorialHtml);
+    }
 
     return {
-        problemStatement,
-        inputSpecification,
-        outputSpecification,
-        inputExample,
-        outputExample
+        index: problemIndex,
+        title: problemName,
+        rawTitle: titleText,
+        timeLimit,
+        memoryLimit,
+        inputFile,
+        outputFile,
+        statementMarkdown: htmlFragmentToMarkdown(problemDescription.join('')),
+        inputMarkdown: htmlFragmentToMarkdown(inputSection),
+        outputMarkdown: htmlFragmentToMarkdown(outputSection),
+        noteMarkdown: htmlFragmentToMarkdown(noteSection),
+        samples,
+        tutorialMarkdown,
     };
 }
 
 module.exports = getProblemDetails;
+


### PR DESCRIPTION
## Summary
- replace the CLI with an option-driven workflow that exports every contest problem and tutorial as Markdown files
- parse Codeforces HTML into clean Markdown with a custom converter and support offline fixtures
- document the new workflow and commit a working offline example with generated output

## Testing
- node script.js 1 --offline-dir fixtures/beta_round_1 --output output --verbose

------
https://chatgpt.com/codex/tasks/task_e_68d8d5dd46d48328a7b5677fe33e6dc4